### PR TITLE
fix: 修复当委托未处于结束状态(如：重复运行)时卡死

### DIFF
--- a/assets/resource/base/pipeline/quest.json
+++ b/assets/resource/base/pipeline/quest.json
@@ -22,8 +22,28 @@
             "type": "Click"
         },
         "focus": {
-            "Node.Recognition.Starting": "正在点击委托"
+            "Node.Recognition.Starting": "正在前往委托"
         },
+        "next": [
+            "委托_异常处理"
+        ],
+        "recognition": {
+            "param": {
+                "template": [
+                    "entrust.png"
+                ]
+            },
+            "type": "TemplateMatch"
+        }
+    },
+    "委托_异常处理": {
+        "action": {
+            "param": {},
+            "type": "DoNothing"
+        },
+        "on_error": [
+            "通用_返回主页"
+        ],
         "next": [
             {
                 "jump_back": true,
@@ -36,12 +56,8 @@
             "委托_再次派遣"
         ],
         "recognition": {
-            "param": {
-                "template": [
-                    "entrust.png"
-                ]
-            },
-            "type": "TemplateMatch"
+            "param": {},
+            "type": "DirectHit"
         }
     },
     "委托_跳过 ": {


### PR DESCRIPTION
由于maa framework框架逻辑，jump_back 任务的on_error _不会被执行_ (*1)   
导致尝试一键领取失败时不会返回主页，"委托_前往委托"node超时退出且没有on_error处理，因此直接进入了下一任务(如好友)   
从而导致连锁失败   

由于"委托_前往委托"node进入位置已经位于主页，无法添加返回主页的on_error，因此选择额外添加中间层控制异常处理   
测试运行符合预期

(*1)：暂时不理解为什么不会被执行，但是感觉不执行逻辑上是对的，jump_back逻辑上是在尝试执行，即接受可能不存在对应条件，如果尝试的过程中直接触发返回主页这样的on_error处理，jump_back的意义就不存在了，退化为和普通next行为一致了；我的理解正确吗？   

另注：正在尝试点击一键赠送 重试次数似乎太多了，感觉已经超过了必要冗余且输出大量日志影响阅读，但是我没有找到控制的位置